### PR TITLE
[FIX] Use all queue heads to create buildsets list

### DIFF
--- a/acid/features/status/model.py
+++ b/acid/features/status/model.py
@@ -23,7 +23,9 @@ class Queue:
     def create(cls, queue):
         buildsets = []
         if len(queue['heads']) > 0:
-            buildsets = [Buildset.create(b) for b in queue['heads'][0]]
+            for head in queue['heads']:
+                for buildset in head:
+                    buildsets.append(Buildset.create(buildset))
         return cls(queue['name'], buildsets)
 
 


### PR DESCRIPTION
We want to make sure that not only first queue[head] is used
to build complete buildsets list.
Similar solution has been used in openstack-infra/zuul
https://github.com/openstack-infra/zuul/blob/master/zuul/web/__init__.py#L68..L76