### PR TITLE
Upgrade PyYAML to 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Jinja2==2.10
 MarkupSafe==1.0
 Werkzeug==0.14.1
 pony==0.7.5
-PyYAML==3.12
+PyYAML==3.13
 PyMySQL==0.9.2
 requests==2.19.1
 Flask-Session==0.3.1


### PR DESCRIPTION
Upgrading PyYAML to new 3.13 version. Old version not working in python 3.7.