### PR TITLE
Use redirect from flask instead of werkzeug

### DIFF
--- a/acid/features/auth/controller.py
+++ b/acid/features/auth/controller.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import requests
 
-from flask import (Blueprint, current_app, make_response,
+from flask import (Blueprint, current_app, make_response, redirect,
                    render_template, request, url_for)
-
-from werkzeug.utils import redirect
 
 from . import service
 


### PR DESCRIPTION
Flask gives us abstraction layer on top of werkzeug server. We should
always pick up high level abstraction first.