### PR TITLE
Exclude tests's files from coverage report

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ env =
 
 [coverage:run]
 source = acid/
+omit = */tests/*
 
 [coverage:report]
 show_missing = yes


### PR DESCRIPTION
Exclude all files in */tests/* from coverage report