### PR TITLE
Update standardJS linter to env browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
       script: tox -e py37
     - name: "StandradJS linter for static/*.js"
       install: npm install -g standard
-      script: standard "static/*.js" --global $ --global moment --global localStorage
+      script: standard "static/*.js" --env browser --env jquery --global moment


### PR DESCRIPTION
Update JavaScript linter in CI - set environments to ``browser`` and ``jQuery``. StandardJS will be know all browser global.