### PR TITLE
Fix zuul-scheduler service startup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Run vagrant for remote services like Zuul and Gerrit for development purposes.
 
     $ make dev-run
 
+After starting up Vagrant machine wait arount 30-40 seconds for Zuul and Gerrit services to properly load.
 
 RUN ACID
 --------
@@ -74,9 +75,3 @@ You can also use tox to run tests against Python 3.6 and 3.7
     $ . .venv/bin/activate
     $ tox
 
-KNOWN ISSUES
-------------
-
-After running :code:`$ make dev-run` integration test (and possibly all connections to ZUUL) will fail.
-
-Current fix is to add read permissions for file :code:`/etc/zuul/zuul.conf` and manually start :code:`zuul-scheduler` service inside 'vagrant'.

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Run vagrant for remote services like Zuul and Gerrit for development purposes.
 
     $ make dev-run
 
-After starting up Vagrant machine wait arount 30-40 seconds for Zuul and Gerrit services to properly load.
+After starting up Vagrant machine wait around 40 seconds for Zuul and Gerrit services to properly load.
 
 RUN ACID
 --------

--- a/playbooks/roles/run-zuul/tasks/main.yml
+++ b/playbooks/roles/run-zuul/tasks/main.yml
@@ -13,4 +13,5 @@
     chdir: /opt/app/playbooks
     executable: /bin/bash
 
+- include_tasks: service.yml
 - include_tasks: website.yml

--- a/playbooks/roles/run-zuul/tasks/service.yml
+++ b/playbooks/roles/run-zuul/tasks/service.yml
@@ -1,0 +1,24 @@
+---
+- name: Change permissions for zuul.conf
+  become: yes
+  file:
+    path: "/etc/zuul/zuul.conf"
+    mode: 0644
+
+- name: Add restart loop for scheduler service
+  become: yes
+  lineinfile:
+          path: /etc/systemd/system/zuul-scheduler.service
+          insertafter: "^\\[Service\\]"
+          line: "{{ item.comm }}={{ item.var}}"
+  with_items:
+          - { comm: "Restart", var: "on-failure" }
+          - { comm: "RestartSec", var: "5" }
+
+- name: Set parameter for restarting scheduler service
+  become: yes
+  lineinfile:
+          path: /etc/systemd/system/zuul-scheduler.service
+          insertafter: "^\\[Unit\\]"
+          line: "StartLimitIntervalSec=0"
+


### PR DESCRIPTION
After starting up Vagrant machine zuul-scheduler service would fail to start.
Added necessary permissions to configuration file and restart option for service.