### PR TITLE
Acid 129 autorefresh collapses expanded buildsets

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -16,7 +16,7 @@ buildset:
   page_links: 4
   log_url: 'http://logs.opencontrail.org'
 zuul:
-  url: 'http://10.10.10.5/'
+  url: 'http://zuulv3.opencontrail.org/'
   status_endpoint: 'status.json'
   pipelines:
     - check

--- a/settings.yml
+++ b/settings.yml
@@ -16,7 +16,7 @@ buildset:
   page_links: 4
   log_url: 'http://logs.opencontrail.org'
 zuul:
-  url: 'http://zuulv3.opencontrail.org/'
+  url: 'http://10.10.10.5/'
   status_endpoint: 'status.json'
   pipelines:
     - check

--- a/static/script.js
+++ b/static/script.js
@@ -33,7 +33,7 @@ $(function () {
         newSessionStorageValue = ids.filter(item => item !== rowId)
       }
     }
-    newSessionStorageValue = newSessionStorageValue.filter(function (e) { return e })
+    newSessionStorageValue = newSessionStorageValue.filter(item => item !== '')
     sessionStorage.setItem('unfoldedRows', newSessionStorageValue)
   })
   $(window).ready(function () {

--- a/static/script.js
+++ b/static/script.js
@@ -13,7 +13,18 @@ $(function () {
   $('.clickable').click(function () {
     $(this).toggleClass('unfold')
     $(this).parent().toggleClass('active-border')
+    let row_id = $(this).attr('id')
+    let urlParams = new URLSearchParams(window.location.search);
+
+    let row_id_flag = urlParams.get(row_id)
+    jQuery.query.set("chuj", 10)
+    if (row_id_flag === 'true'){
+      alert('yes')
+    }
   })
+
+
+
 })
 
 function enableAutoRefresh () { // eslint-disable-line no-unused-vars

--- a/static/script.js
+++ b/static/script.js
@@ -11,18 +11,32 @@ $(function () {
   })
 
   $('.clickable').click(function () {
+    let all_unfold_ids = sessionStorage.getItem('unfolded_rows')
+    let row_id = $(this).attr('id')
     $(this).toggleClass('unfold')
     $(this).parent().toggleClass('active-border')
-    let row_id = $(this).attr('id')
-    let urlParams = new URLSearchParams(window.location.search);
-
-    let row_id_flag = urlParams.get(row_id)
-    jQuery.query.set("chuj", 10)
-    if (row_id_flag === 'true'){
-      alert('yes')
+    row_id = row_id.replace("heading", "collapse")
+    if (all_unfold_ids === null) {
+      sessionStorage.setItem('unfolded_rows', row_id + ",")
+    } else {
+      ids = all_unfold_ids.split(',')
+      current_id_index = ids.indexOf(row_id)
+      if ( current_id_index === - 1) {
+        sessionStorage.setItem('unfolded_rows', all_unfold_ids + row_id + ",")
+      } else {
+        ids.splice(current_id_index,1)
+        sessionStorage.setItem('unfolded_rows', ids)
+      }
     }
   })
 
+  $(window).ready(function() {
+    let all_unfold_ids = sessionStorage.getItem('unfolded_rows')
+    ids_to_unfold = all_unfold_ids.split(',')
+    for (id of ids_to_unfold){
+        $('#'+id).addClass('show')
+    }
+})
 
 
 })

--- a/static/script.js
+++ b/static/script.js
@@ -15,7 +15,7 @@ $(function () {
 
     let allUnfoldIds = sessionStorage.getItem('unfoldedRows')
     let rowId = $item.attr('id')
-    let newSessionStorageValue = ''
+    let newSessionStorageValue = []
 
     $item.toggleClass('unfold')
     $item.parent().toggleClass('active-border')
@@ -23,17 +23,17 @@ $(function () {
     rowId = rowId.replace('heading', 'collapse')
 
     if (allUnfoldIds === null) {
-      newSessionStorageValue = rowId + ','
+      newSessionStorageValue.push(rowId)
     } else {
       let ids = allUnfoldIds.split(',')
-      let currentIdIndex = ids.indexOf(rowId)
-      if (currentIdIndex === -1) {
-        newSessionStorageValue = allUnfoldIds + rowId + ','
+      newSessionStorageValue = ids
+      if (ids.indexOf(rowId) === -1) {
+        newSessionStorageValue.push(rowId)
       } else {
-        ids.splice(currentIdIndex, 1)
-        newSessionStorageValue = ids
+        newSessionStorageValue = ids.filter(item => item !== rowId)
       }
     }
+    newSessionStorageValue = newSessionStorageValue.filter(function(e){return e})
     sessionStorage.setItem('unfoldedRows', newSessionStorageValue)
   })
   $(window).ready(function () {

--- a/static/script.js
+++ b/static/script.js
@@ -33,7 +33,7 @@ $(function () {
         newSessionStorageValue = ids.filter(item => item !== rowId)
       }
     }
-    newSessionStorageValue = newSessionStorageValue.filter(function(e){return e})
+    newSessionStorageValue = newSessionStorageValue.filter(function (e) { return e })
     sessionStorage.setItem('unfoldedRows', newSessionStorageValue)
   })
   $(window).ready(function () {

--- a/static/script.js
+++ b/static/script.js
@@ -11,34 +11,38 @@ $(function () {
   })
 
   $('.clickable').click(function () {
-    let all_unfold_ids = sessionStorage.getItem('unfolded_rows')
-    let row_id = $(this).attr('id')
-    $(this).toggleClass('unfold')
-    $(this).parent().toggleClass('active-border')
-    row_id = row_id.replace("heading", "collapse")
-    if (all_unfold_ids === null) {
-      sessionStorage.setItem('unfolded_rows', row_id + ",")
+    let $item = $(this)
+
+    let allUnfoldIds = sessionStorage.getItem('unfoldedRows')
+    let rowId = $item.attr('id')
+    let newSessionStorageValue = ''
+
+    $item.toggleClass('unfold')
+    $item.parent().toggleClass('active-border')
+
+    rowId = rowId.replace('heading', 'collapse')
+
+    if (allUnfoldIds === null) {
+      newSessionStorageValue = rowId + ','
     } else {
-      ids = all_unfold_ids.split(',')
-      current_id_index = ids.indexOf(row_id)
-      if ( current_id_index === - 1) {
-        sessionStorage.setItem('unfolded_rows', all_unfold_ids + row_id + ",")
+      let ids = allUnfoldIds.split(',')
+      let currentIdIndex = ids.indexOf(rowId)
+      if (currentIdIndex === -1) {
+        newSessionStorageValue = allUnfoldIds + rowId + ','
       } else {
-        ids.splice(current_id_index,1)
-        sessionStorage.setItem('unfolded_rows', ids)
+        ids.splice(currentIdIndex, 1)
+        newSessionStorageValue = ids
       }
     }
+    sessionStorage.setItem('unfoldedRows', newSessionStorageValue)
   })
-
-  $(window).ready(function() {
-    let all_unfold_ids = sessionStorage.getItem('unfolded_rows')
-    ids_to_unfold = all_unfold_ids.split(',')
-    for (id of ids_to_unfold){
-        $('#'+id).addClass('show')
+  $(window).ready(function () {
+    let allUnfoldIds = sessionStorage.getItem('unfoldedRows')
+    let idsToUnfold = allUnfoldIds.split(',')
+    for (let id of idsToUnfold) {
+      $('#' + id).addClass('show')
     }
-})
-
-
+  })
 })
 
 function enableAutoRefresh () { // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Fixing bug - folding rows during refresh. Added JavaScript function to do job done.