### PR TITLE
Fixed branch name comparison in build history

### DIFF
--- a/acid/features/history/model.py
+++ b/acid/features/history/model.py
@@ -87,7 +87,7 @@ class ZuulBuildSet(db.Entity):
 
         return select(
             bs for bs in cls if
-            bs.pipeline == pipeline and bs.ref.endswith(branch) and
+            bs.pipeline == pipeline and bs.branch == branch and
             len(select(b for b in bs.builds if
                        build in b.log_url)) > 0).sort_by(desc(cls.id))
 


### PR DESCRIPTION
Previously branch in the database only had to end with requested branch name