### PR TITLE
Changed head to heads in zuul manager

### DIFF
--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -41,7 +41,7 @@ class ZuulManager:
 
     def _sanitize_args(self, pipeline, branch):
         sanitized_pipeline = shlex.quote(pipeline)
-        sanitized_ref = shlex.quote(f'refs/head/{branch}')
+        sanitized_ref = shlex.quote(f'refs/heads/{branch}')
         return sanitized_pipeline, sanitized_ref
 
     def _prepare_client(self):

--- a/acid/features/zuul_manager/tests/test_manager.py
+++ b/acid/features/zuul_manager/tests/test_manager.py
@@ -74,7 +74,7 @@ class TestZuulConnector:
 
         run_command.assert_called_with(
             'zuul enqueue-ref --tenant tenant --trigger trigger --pipeline '
-            'periodic-nightly --project project --ref refs/head/master '
+            'periodic-nightly --project project --ref refs/heads/master '
             '> /dev/null 2>&1 &')
 
     def test_dequeue_generate_correct_command(self, path_to_test_file, mocker):
@@ -91,7 +91,7 @@ class TestZuulConnector:
 
         run_command.assert_called_with(
             'zuul dequeue --tenant tenant --pipeline periodic-nightly '
-            '--project project --ref refs/head/master > /dev/null 2>&1 &')
+            '--project project --ref refs/heads/master > /dev/null 2>&1 &')
 
     def test_enqueue_correct_escape_insecure_args(self, path_to_test_file,
                                                   mocker):
@@ -109,7 +109,7 @@ class TestZuulConnector:
         run_command.assert_called_with(
             'zuul enqueue-ref --tenant TENANT '
             '--trigger TRIGGER --pipeline \'periodic`who`\' --project PROJECT '
-            '--ref \'refs/head/master???*\' > /dev/null 2>&1 &')
+            '--ref \'refs/heads/master???*\' > /dev/null 2>&1 &')
 
     def test_dequeue_correct_escape_insecure_args(self, path_to_test_file,
                                                   mocker):
@@ -126,4 +126,4 @@ class TestZuulConnector:
 
         run_command.assert_called_with(
             'zuul dequeue --tenant TENANT --pipeline \'rm -r /\' --project '
-            'PROJECT --ref \'refs/head/master*/~\' > /dev/null 2>&1 &')
+            'PROJECT --ref \'refs/heads/master*/~\' > /dev/null 2>&1 &')


### PR DESCRIPTION
There was a typo in branch reference sanitization. Entity "refs/head/..." do not exist in git.