### PR TITLE
Add Zuul configuration as parameter to Zuul Manager

### DIFF
--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -5,6 +5,8 @@ import paramiko
 
 from .exceptions import ZuulManagerConfig, ZuulManagerConn
 
+from flask import current_app
+
 
 class ZuulManager:
     def __init__(self, host, username, user_key_file, host_key_file,
@@ -26,7 +28,15 @@ class ZuulManager:
 
     def enqueue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
-        command = str(f"zuul enqueue-ref --tenant {self.tenant} "
+
+        conf_path = current_app.config.get("gearman_conf", None) #f"/home/vagrant/gearman_conf/gear.conf"
+
+        if conf_path and len(conf_path) > 0:
+            c = f"-c {conf_path}"
+        else:
+            c = ""
+
+        command = str(f"zuul {c} enqueue-ref --tenant {self.tenant} "
                       f"--trigger {self.trigger} --pipeline {pipeline} "
                       f"--project {self.project} --ref {ref} "
                       "> /dev/null 2>&1 &")
@@ -34,7 +44,15 @@ class ZuulManager:
 
     def dequeue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
-        command = str(f"zuul dequeue --tenant {self.tenant} "
+
+        conf_path = current_app.config.get("gearman_conf", None)  # f"/home/vagrant/gearman_conf/gear.conf"
+
+        if conf_path and len(conf_path) > 0:
+            c = f"-c {conf_path}"
+        else:
+            c = ""
+
+        command = str(f"zuul {c} dequeue --tenant {self.tenant} "
                       f"--pipeline {pipeline} --project {self.project} "
                       f"--ref {ref} > /dev/null 2>&1 &")
         self._run_command(command)

--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -28,15 +28,13 @@ class ZuulManager:
 
     def enqueue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
-
-        conf_path = current_app.config.get("gearman_conf", None) #f"/home/vagrant/gearman_conf/gear.conf"
-
+        conf_path = current_app.config.get("gearman_conf", None)
         if conf_path and len(conf_path) > 0:
-            c = f"-c {conf_path}"
+            c = f" -c {conf_path}"
         else:
             c = ""
 
-        command = str(f"zuul {c} enqueue-ref --tenant {self.tenant} "
+        command = str(f"zuul{c} enqueue-ref --tenant {self.tenant} "
                       f"--trigger {self.trigger} --pipeline {pipeline} "
                       f"--project {self.project} --ref {ref} "
                       "> /dev/null 2>&1 &")
@@ -44,15 +42,13 @@ class ZuulManager:
 
     def dequeue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
-
-        conf_path = current_app.config.get("gearman_conf", None)  # f"/home/vagrant/gearman_conf/gear.conf"
-
+        conf_path = current_app.config.get("gearman_conf", None)
         if conf_path and len(conf_path) > 0:
-            c = f"-c {conf_path}"
+            c = f" -c {conf_path}"
         else:
             c = ""
 
-        command = str(f"zuul {c} dequeue --tenant {self.tenant} "
+        command = str(f"zuul{c} dequeue --tenant {self.tenant} "
                       f"--pipeline {pipeline} --project {self.project} "
                       f"--ref {ref} > /dev/null 2>&1 &")
         self._run_command(command)

--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -28,7 +28,9 @@ class ZuulManager:
 
     def enqueue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
-        conf_path = current_app.config.get("gearman_conf", None)
+        config = current_app.config
+        conf_path = config.get("gearman_conf", None)
+
         if conf_path and len(conf_path) > 0:
             c = f" -c {conf_path}"
         else:
@@ -42,7 +44,9 @@ class ZuulManager:
 
     def dequeue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
-        conf_path = current_app.config.get("gearman_conf", None)
+        config = current_app.config
+        conf_path = config.get("gearman_conf", None)
+
         if conf_path and len(conf_path) > 0:
             c = f" -c {conf_path}"
         else:

--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -57,7 +57,7 @@ class ZuulManager:
             config = current_app.config
             conf_path = config['zuul'].get('gearman_conf', None)
 
-            conf_arg = ""
+        conf_arg = ""
         # check if path isn't empty
         if conf_path and len(str(conf_path)) > 0:
             # simple path validation

--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -29,9 +29,9 @@ class ZuulManager:
     def enqueue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
 
-        c = self._gearman_conf_arg()
+        conf_arg = self._gearman_conf_arg()
 
-        command = str(f"zuul{c} enqueue-ref --tenant {self.tenant} "
+        command = str(f"zuul{conf_arg} enqueue-ref --tenant {self.tenant} "
                       f"--trigger {self.trigger} --pipeline {pipeline} "
                       f"--project {self.project} --ref {ref} "
                       "> /dev/null 2>&1 &")
@@ -40,9 +40,9 @@ class ZuulManager:
     def dequeue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
 
-        c = self._gearman_conf_arg()
+        conf_arg = self._gearman_conf_arg()
 
-        command = str(f"zuul{c} dequeue --tenant {self.tenant} "
+        command = str(f"zuul{conf_arg} dequeue --tenant {self.tenant} "
                       f"--pipeline {pipeline} --project {self.project} "
                       f"--ref {ref} > /dev/null 2>&1 &")
         self._run_command(command)
@@ -57,18 +57,18 @@ class ZuulManager:
             config = current_app.config
             conf_path = config['zuul'].get('gearman_conf', None)
 
-        c = ""
+            conf_arg = ""
         # check if path isn't empty
         if conf_path and len(str(conf_path)) > 0:
             # simple path validation
             # format: /path/to/file.conf
             if conf_path[0] == '/' and conf_path.endswith('.conf'):
-                c = f" -c {conf_path}"
+                conf_arg = f" -c {conf_path}"
             else:
                 print(f" * Invalid path to gearman configuration file!\n"
                       f" * Path should be in format: /path/to/file.conf\n"
                       f" * Given path: {conf_path}")
-        return c
+        return conf_arg
 
     def _prepare_client(self):
         client = paramiko.SSHClient()

--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -35,7 +35,6 @@ class ZuulManager:
                       f"--trigger {self.trigger} --pipeline {pipeline} "
                       f"--project {self.project} --ref {ref} "
                       "> /dev/null 2>&1 &")
-        print(command)
         self._run_command(command)
 
     def dequeue(self, pipeline, branch):

--- a/acid/features/zuul_manager/manager.py
+++ b/acid/features/zuul_manager/manager.py
@@ -29,7 +29,7 @@ class ZuulManager:
     def enqueue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
 
-        c = self._get_gearman_conf_arg()
+        c = self._gearman_conf_arg()
 
         command = str(f"zuul{c} enqueue-ref --tenant {self.tenant} "
                       f"--trigger {self.trigger} --pipeline {pipeline} "
@@ -40,7 +40,7 @@ class ZuulManager:
     def dequeue(self, pipeline, branch):
         pipeline, ref = self._sanitize_args(pipeline, branch)
 
-        c = self._get_gearman_conf_arg()
+        c = self._gearman_conf_arg()
 
         command = str(f"zuul{c} dequeue --tenant {self.tenant} "
                       f"--pipeline {pipeline} --project {self.project} "
@@ -52,21 +52,21 @@ class ZuulManager:
         sanitized_ref = shlex.quote(f'refs/heads/{branch}')
         return sanitized_pipeline, sanitized_ref
 
-    def _get_gearman_conf_arg(self, conf_path=None):
+    def _gearman_conf_arg(self, conf_path=None):
         if conf_path is None:
             config = current_app.config
-            conf_path = config.get('gearman_conf', None)
+            conf_path = config['zuul'].get('gearman_conf', None)
 
         c = ""
         # check if path isn't empty
         if conf_path and len(str(conf_path)) > 0:
             # simple path validation
-            # format: /path/to/config.conf
+            # format: /path/to/file.conf
             if conf_path[0] == '/' and conf_path.endswith('.conf'):
                 c = f" -c {conf_path}"
             else:
                 print(f" * Invalid path to gearman configuration file!\n"
-                      f" * Path should be in format: /path/to/config/file.conf\n"
+                      f" * Path should be in format: /path/to/file.conf\n"
                       f" * Given path: {conf_path}")
         return c
 

--- a/acid/features/zuul_manager/tests/test_manager.py
+++ b/acid/features/zuul_manager/tests/test_manager.py
@@ -3,6 +3,7 @@ import pytest
 
 from ..manager import ZuulManager
 from ..exceptions import ZuulManagerConfig
+
 from acid.tests import IntegrationTestCase
 
 

--- a/acid/features/zuul_manager/tests/test_manager.py
+++ b/acid/features/zuul_manager/tests/test_manager.py
@@ -8,7 +8,7 @@ from acid.tests import IntegrationTestCase
 
 
 @pytest.mark.unit
-class TestZuulConnector(IntegrationTestCase):
+class TestZuulConnector():
     def test_raise_when_no_user_key_file(self, path_to_test_file):
         with pytest.raises(ZuulManagerConfig):
             ZuulManager(host="host",
@@ -18,7 +18,8 @@ class TestZuulConnector(IntegrationTestCase):
                         tenant="tenant",
                         trigger="trigger",
                         project="project",
-                        policy="AutoAddPolicy")
+                        policy="AutoAddPolicy",
+                        gearman_conf="/path/to/file/.conf")
 
     def test_raise_when_no_host_keys_file(self, path_to_test_file):
         with pytest.raises(ZuulManagerConfig):
@@ -29,7 +30,8 @@ class TestZuulConnector(IntegrationTestCase):
                         tenant="tenant",
                         trigger="trigger",
                         project="project",
-                        policy="AutoAddPolicy")
+                        policy="AutoAddPolicy",
+                        gearman_conf="/path/to/file/.conf")
 
     def test_can_set_autoadd_policy(self, path_to_test_file):
         ZuulManager(host="host",
@@ -39,7 +41,8 @@ class TestZuulConnector(IntegrationTestCase):
                     tenant="tenant",
                     trigger="trigger",
                     project="project",
-                    policy="AutoAddPolicy")
+                    policy="AutoAddPolicy",
+                    gearman_conf="/path/to/file/.conf")
 
     def test_can_set_reject_policy(self, path_to_test_file):
         ZuulManager(host="host",
@@ -49,7 +52,8 @@ class TestZuulConnector(IntegrationTestCase):
                     tenant="tenant",
                     trigger="trigger",
                     project="project",
-                    policy="RejectPolicy")
+                    policy="RejectPolicy",
+                    gearman_conf="/path/to/file/.conf")
 
     def test_raise_when_try_to_set_not_exists_policy(self, path_to_test_file):
         with pytest.raises(ZuulManagerConfig):
@@ -60,7 +64,8 @@ class TestZuulConnector(IntegrationTestCase):
                         tenant="tenant",
                         trigger="trigger",
                         project="project",
-                        policy="no-policy")
+                        policy="no-policy",
+                        gearman_conf="/path/to/file/.conf")
 
     def test_enqueue_generate_correct_command(self, path_to_test_file, mocker):
         run_command = mocker.patch.object(ZuulManager, '_run_command')
@@ -71,11 +76,12 @@ class TestZuulConnector(IntegrationTestCase):
                            tenant="tenant",
                            trigger="trigger",
                            project="project",
-                           policy="AutoAddPolicy")
+                           policy="AutoAddPolicy",
+                           gearman_conf="/path/to/file/.conf")
         zuul.enqueue(pipeline="periodic-nightly", branch="master")
 
         run_command.assert_called_with(
-            'zuul enqueue-ref --tenant tenant --trigger trigger --pipeline '
+            'zuul -c /path/to/file/.conf enqueue-ref --tenant tenant --trigger trigger --pipeline '
             'periodic-nightly --project project --ref refs/heads/master '
             '> /dev/null 2>&1 &')
 
@@ -88,11 +94,12 @@ class TestZuulConnector(IntegrationTestCase):
                            tenant="tenant",
                            trigger="trigger",
                            project="project",
-                           policy="AutoAddPolicy")
+                           policy="AutoAddPolicy",
+                           gearman_conf="/path/to/file/.conf")
         zuul.dequeue(pipeline="periodic-nightly", branch="master")
 
         run_command.assert_called_with(
-            'zuul dequeue --tenant tenant --pipeline periodic-nightly '
+            'zuul -c /path/to/file/.conf dequeue --tenant tenant --pipeline periodic-nightly '
             '--project project --ref refs/heads/master > /dev/null 2>&1 &')
 
     def test_enqueue_correct_escape_insecure_args(self, path_to_test_file,
@@ -105,11 +112,12 @@ class TestZuulConnector(IntegrationTestCase):
                            tenant="TENANT",
                            trigger="TRIGGER",
                            project="PROJECT",
-                           policy="AutoAddPolicy")
+                           policy="AutoAddPolicy",
+                           gearman_conf="/path/to/file/.conf")
         zuul.enqueue(pipeline="periodic`who`", branch="master???*")
 
         run_command.assert_called_with(
-            'zuul enqueue-ref --tenant TENANT '
+            'zuul -c /path/to/file/.conf enqueue-ref --tenant TENANT '
             '--trigger TRIGGER --pipeline \'periodic`who`\' --project PROJECT '
             '--ref \'refs/heads/master???*\' > /dev/null 2>&1 &')
 
@@ -123,9 +131,47 @@ class TestZuulConnector(IntegrationTestCase):
                            tenant="TENANT",
                            trigger="TRIGGER",
                            project="PROJECT",
-                           policy="AutoAddPolicy")
+                           policy="AutoAddPolicy",
+                           gearman_conf="/path/to/file/.conf")
         zuul.dequeue(pipeline="rm -r /", branch="master*/~")
 
         run_command.assert_called_with(
-            'zuul dequeue --tenant TENANT --pipeline \'rm -r /\' --project '
+            'zuul -c /path/to/file/.conf dequeue --tenant TENANT --pipeline \'rm -r /\' --project '
             'PROJECT --ref \'refs/heads/master*/~\' > /dev/null 2>&1 &')
+
+    def test_enqueue_incorect_gearman_conf(self, path_to_test_file,
+                                           mocker):
+        run_command = mocker.patch.object(ZuulManager, '_run_command')
+        zuul = ZuulManager(host="host",
+                           username="user",
+                           user_key_file=path_to_test_file("insecure_user_key"),
+                           host_key_file=path_to_test_file("host_key.pub"),
+                           tenant="tenant",
+                           trigger="trigger",
+                           project="project",
+                           policy="AutoAddPolicy",
+                           gearman_conf="incorrect/path/to/file/.con")
+        zuul.enqueue(pipeline="periodic-nightly", branch="master")
+
+        run_command.assert_called_with(
+            'zuul  enqueue-ref --tenant tenant --trigger trigger --pipeline '
+            'periodic-nightly --project project --ref refs/heads/master '
+            '> /dev/null 2>&1 &')
+
+    def test_dequeue_incorect_gearman_conf(self, path_to_test_file,
+                                           mocker):
+        run_command = mocker.patch.object(ZuulManager, '_run_command')
+        zuul = ZuulManager(host="host",
+                           username="user",
+                           user_key_file=path_to_test_file("insecure_user_key"),
+                           host_key_file=path_to_test_file("host_key.pub"),
+                           tenant="tenant",
+                           trigger="trigger",
+                           project="project",
+                           policy="AutoAddPolicy",
+                           gearman_conf="incorrect/path/to/file/.con")
+        zuul.dequeue(pipeline="periodic-nightly", branch="master")
+
+        run_command.assert_called_with(
+            'zuul  dequeue --tenant tenant --pipeline periodic-nightly '
+            '--project project --ref refs/heads/master > /dev/null 2>&1 &')

--- a/acid/features/zuul_manager/tests/test_manager.py
+++ b/acid/features/zuul_manager/tests/test_manager.py
@@ -3,10 +3,11 @@ import pytest
 
 from ..manager import ZuulManager
 from ..exceptions import ZuulManagerConfig
+from acid.tests import IntegrationTestCase
 
 
 @pytest.mark.unit
-class TestZuulConnector:
+class TestZuulConnector(IntegrationTestCase):
     def test_raise_when_no_user_key_file(self, path_to_test_file):
         with pytest.raises(ZuulManagerConfig):
             ZuulManager(host="host",

--- a/acid/features/zuul_manager/tests/test_manager.py
+++ b/acid/features/zuul_manager/tests/test_manager.py
@@ -4,8 +4,6 @@ import pytest
 from ..manager import ZuulManager
 from ..exceptions import ZuulManagerConfig
 
-from acid.tests import IntegrationTestCase
-
 
 @pytest.mark.unit
 class TestZuulConnector():
@@ -81,9 +79,9 @@ class TestZuulConnector():
         zuul.enqueue(pipeline="periodic-nightly", branch="master")
 
         run_command.assert_called_with(
-            'zuul -c /path/to/file/.conf enqueue-ref --tenant tenant --trigger trigger --pipeline '
-            'periodic-nightly --project project --ref refs/heads/master '
-            '> /dev/null 2>&1 &')
+            'zuul -c /path/to/file/.conf enqueue-ref --tenant tenant --trigger '
+            'trigger --pipeline periodic-nightly --project project '
+            '--ref refs/heads/master > /dev/null 2>&1 &')
 
     def test_dequeue_generate_correct_command(self, path_to_test_file, mocker):
         run_command = mocker.patch.object(ZuulManager, '_run_command')
@@ -99,8 +97,9 @@ class TestZuulConnector():
         zuul.dequeue(pipeline="periodic-nightly", branch="master")
 
         run_command.assert_called_with(
-            'zuul -c /path/to/file/.conf dequeue --tenant tenant --pipeline periodic-nightly '
-            '--project project --ref refs/heads/master > /dev/null 2>&1 &')
+            'zuul -c /path/to/file/.conf dequeue --tenant tenant '
+            '--pipeline periodic-nightly --project project '
+            '--ref refs/heads/master > /dev/null 2>&1 &')
 
     def test_enqueue_correct_escape_insecure_args(self, path_to_test_file,
                                                   mocker):
@@ -136,8 +135,9 @@ class TestZuulConnector():
         zuul.dequeue(pipeline="rm -r /", branch="master*/~")
 
         run_command.assert_called_with(
-            'zuul -c /path/to/file/.conf dequeue --tenant TENANT --pipeline \'rm -r /\' --project '
-            'PROJECT --ref \'refs/heads/master*/~\' > /dev/null 2>&1 &')
+            'zuul -c /path/to/file/.conf dequeue --tenant TENANT '
+            '--pipeline \'rm -r /\' --project PROJECT '
+            '--ref \'refs/heads/master*/~\' > /dev/null 2>&1 &')
 
     def test_enqueue_incorect_gearman_conf(self, path_to_test_file,
                                            mocker):

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -112,3 +112,8 @@ zuul:
 
     # Policy to use when connecting to server without host key.
     policy: 'RejectPolicy'
+
+    # Path to file which contains configuration for gearman connection
+    # Path should be absolute and lead to .conf file
+    # In case of empty path default zuul configuration file is used
+    gearman_conf: ''

--- a/config/test/settings_test.yml.sample
+++ b/config/test/settings_test.yml.sample
@@ -46,4 +46,4 @@ zuul:
     project: 'acid-test-dev'
     trigger: 'timer'
     policy: 'RejectPolicy'
-gearman_conf: '/home/vagrant/gearman_conf/gear.conf'
+  gearman_conf: ''

--- a/config/test/settings_test.yml.sample
+++ b/config/test/settings_test.yml.sample
@@ -46,3 +46,4 @@ zuul:
     project: 'acid-test-dev'
     trigger: 'timer'
     policy: 'RejectPolicy'
+gearman_conf: '/home/vagrant/gearman_conf/gear.conf'


### PR DESCRIPTION
Added path to gearman configuration as parameter passed to zuul in command.
Path is specified as absolute path in `settings.yaml` in `['zuul']['gearman_conf']` field. If path is empty or does not lead to `.conf` file, default zuul configuration file is used.
User has to provide correct configuration file for gearman otherwise job won't be passed to zuul components.