### PR TITLE
List of pipelines should be intersection of pipelines from config and from status.json

### DIFF
--- a/acid/app.py
+++ b/acid/app.py
@@ -11,7 +11,8 @@ from acid.features.auth.controller import auth
 from acid.features.auth.model import get_current_user
 from acid.features.history.controller import builds
 from acid.features.status.controller import status
-from acid.features.status.service import get_zuul_pipelines, pipe_intersect
+from acid.features.status.service import get_zuul_pipelines
+from acid.utils import pipe_intersect
 from acid.features.zuul_manager.controller import zuul_manager
 
 if os.getenv('FLASK_ENV') == 'production' and not os.getenv('SECRET_KEY'):

--- a/acid/app.py
+++ b/acid/app.py
@@ -11,7 +11,7 @@ from acid.features.auth.controller import auth
 from acid.features.auth.model import get_current_user
 from acid.features.history.controller import builds
 from acid.features.status.controller import status
-from acid.features.status.service import pipe_intersect, get_zuul_pipelines
+from acid.features.status.service import get_zuul_pipelines, pipe_intersect
 from acid.features.zuul_manager.controller import zuul_manager
 
 if os.getenv('FLASK_ENV') == 'production' and not os.getenv('SECRET_KEY'):

--- a/acid/app.py
+++ b/acid/app.py
@@ -11,6 +11,7 @@ from acid.features.auth.controller import auth
 from acid.features.auth.model import get_current_user
 from acid.features.history.controller import builds
 from acid.features.status.controller import status
+from acid.features.status.service import get_pipelines
 from acid.features.zuul_manager.controller import zuul_manager
 
 if os.getenv('FLASK_ENV') == 'production' and not os.getenv('SECRET_KEY'):
@@ -39,5 +40,5 @@ app.register_blueprint(zuul_manager)
 
 @app.context_processor
 def template_context():
-    return {'pipeline_names': app.config['zuul']['pipelines'],
+    return {'pipeline_names': get_pipelines(),
             'current_user': get_current_user()}

--- a/acid/app.py
+++ b/acid/app.py
@@ -11,7 +11,7 @@ from acid.features.auth.controller import auth
 from acid.features.auth.model import get_current_user
 from acid.features.history.controller import builds
 from acid.features.status.controller import status
-from acid.features.status.service import get_pipelines
+from acid.features.status.service import pipelines_intersection, get_zuul_pipelines
 from acid.features.zuul_manager.controller import zuul_manager
 
 if os.getenv('FLASK_ENV') == 'production' and not os.getenv('SECRET_KEY'):
@@ -40,5 +40,6 @@ app.register_blueprint(zuul_manager)
 
 @app.context_processor
 def template_context():
-    return {'pipeline_names': get_pipelines(),
+    return {'pipeline_names': pipelines_intersection(app.config['zuul']['pipelines'],
+                                                     get_zuul_pipelines()),
             'current_user': get_current_user()}

--- a/acid/app.py
+++ b/acid/app.py
@@ -11,7 +11,7 @@ from acid.features.auth.controller import auth
 from acid.features.auth.model import get_current_user
 from acid.features.history.controller import builds
 from acid.features.status.controller import status
-from acid.features.status.service import pipelines_intersection, get_zuul_pipelines
+from acid.features.status.service import pipe_intersect, get_zuul_pipelines
 from acid.features.zuul_manager.controller import zuul_manager
 
 if os.getenv('FLASK_ENV') == 'production' and not os.getenv('SECRET_KEY'):
@@ -40,6 +40,6 @@ app.register_blueprint(zuul_manager)
 
 @app.context_processor
 def template_context():
-    return {'pipeline_names': pipelines_intersection(app.config['zuul']['pipelines'],
-                                                     get_zuul_pipelines()),
+    return {'pipeline_names': pipe_intersect(app.config['zuul']['pipelines'],
+                                             get_zuul_pipelines()),
             'current_user': get_current_user()}

--- a/acid/features/status/controller.py
+++ b/acid/features/status/controller.py
@@ -15,7 +15,8 @@ def show_status(pipename=None):
 
     pipename = (pipename if pipename is not None else
                 config['default']['pipename'])
-    queues = service.make_queues(service.get_zuul_pipelines(), pipename, zuul_url)
+    queues = service.make_queues(service.get_zuul_pipelines(),
+                                 pipename, zuul_url)
     refs_list = ["collapse" + buildset.ref for queue in queues
                  for buildset in queue.buildsets]
 

--- a/acid/features/status/controller.py
+++ b/acid/features/status/controller.py
@@ -29,11 +29,6 @@ def show_status(pipename=None):
 @status.route('/')
 def show_dashboard():
     config = current_app.config
-    zuul_url = config['zuul']['url']
-    zuul_endpoint = config['zuul']['status_endpoint']
-
-    url = service.status_endpoint(zuul_url, zuul_endpoint)
-    resource = service.fetch_json_data(endpoint=url)
     pipeline_stats = service.pipelines_stats(
-        resource['pipelines'], config['zuul']['pipelines'])
+        service.get_zuul_pipelines(), config['zuul']['pipelines'])
     return render_template('dashboard.html', pipeline_stats=pipeline_stats)

--- a/acid/features/status/controller.py
+++ b/acid/features/status/controller.py
@@ -12,13 +12,10 @@ status = Blueprint('status', __name__, template_folder='../../templates')
 def show_status(pipename=None):
     config = current_app.config
     zuul_url = config['zuul']['url']
-    zuul_endpoint = config['zuul']['status_endpoint']
 
     pipename = (pipename if pipename is not None else
                 config['default']['pipename'])
-    url = service.status_endpoint(zuul_url, zuul_endpoint)
-    resource = service.fetch_json_data(endpoint=url)
-    queues = service.make_queues(resource['pipelines'], pipename, zuul_url)
+    queues = service.make_queues(service.get_zuul_pipelines(), pipename, zuul_url)
     refs_list = ["collapse" + buildset.ref for queue in queues
                  for buildset in queue.buildsets]
 

--- a/acid/features/status/service.py
+++ b/acid/features/status/service.py
@@ -18,6 +18,9 @@ def fetch_json_data(endpoint):
 
 
 def pipelines_stats(pipelines, showed_pipelines):
+    if not showed_pipelines:
+        return []
+
     pipeline_stats = []
     for pipeline in pipelines:
         if pipeline['name'] in showed_pipelines:
@@ -29,6 +32,29 @@ def pipelines_stats(pipelines, showed_pipelines):
             pipeline_stats.append(PipelineStat(name=pipeline['name'],
                                                buildsets_count=buildsets_count))
     return pipeline_stats
+
+
+def get_zuul_pipelines():
+    config = current_app.config
+    zuul_url = config['zuul']['url']
+    zuul_endpoint = config['zuul']['status_endpoint']
+
+    url = status_endpoint(zuul_url, zuul_endpoint)
+    return fetch_json_data(endpoint=url)['pipelines']
+
+
+def pipelines_intersection(pipelines_config, pipelines_json):
+    if not pipelines_config or not pipelines_json:
+        return []
+
+    pipelines_to_show = [pipeline['name'] for pipeline in pipelines_json
+                         if pipeline['name'] in pipelines_config]
+    return pipelines_to_show
+
+
+def get_pipelines():
+    config = current_app.config
+    return pipelines_intersection(config['zuul']['pipelines'], get_zuul_pipelines())
 
 
 def make_queues(pipelines, pipename, zuul_url):

--- a/acid/features/status/service.py
+++ b/acid/features/status/service.py
@@ -43,7 +43,7 @@ def get_zuul_pipelines():
     return fetch_json_data(endpoint=url)['pipelines']
 
 
-def pipelines_intersection(pipelines_config, pipelines_json):
+def pipe_intersect(pipelines_config, pipelines_json):
     if not pipelines_config or not pipelines_json:
         return []
 

--- a/acid/features/status/service.py
+++ b/acid/features/status/service.py
@@ -18,7 +18,7 @@ def fetch_json_data(endpoint):
 
 
 def pipelines_stats(pipelines, showed_pipelines):
-    if not showed_pipelines:
+    if not pipelines or not showed_pipelines:
         return []
 
     pipeline_stats = []
@@ -40,7 +40,7 @@ def get_zuul_pipelines():
     zuul_endpoint = config['zuul']['status_endpoint']
 
     url = status_endpoint(zuul_url, zuul_endpoint)
-    return fetch_json_data(endpoint=url)['pipelines']
+    return fetch_json_data(endpoint=url).get('pipelines')
 
 
 def pipe_intersect(pipelines_config, pipelines_json):

--- a/acid/features/status/service.py
+++ b/acid/features/status/service.py
@@ -52,11 +52,6 @@ def pipelines_intersection(pipelines_config, pipelines_json):
     return pipelines_to_show
 
 
-def get_pipelines():
-    config = current_app.config
-    return pipelines_intersection(config['zuul']['pipelines'], get_zuul_pipelines())
-
-
 def make_queues(pipelines, pipename, zuul_url):
     for pipeline in pipelines:
         if pipeline['name'] == pipename:

--- a/acid/features/status/service.py
+++ b/acid/features/status/service.py
@@ -40,11 +40,11 @@ def get_zuul_pipelines():
     zuul_endpoint = config['status_endpoint']
     url = status_endpoint(zuul_url, zuul_endpoint)
 
-    result = []
     try:
         result = fetch_json_data(endpoint=url).get('pipelines')
     except RemoteServerError:
         print("Couldn't fetch .json file")
+        result = []
     return result
 
 

--- a/acid/features/status/service.py
+++ b/acid/features/status/service.py
@@ -35,21 +35,17 @@ def pipelines_stats(pipelines, showed_pipelines):
 
 
 def get_zuul_pipelines():
-    config = current_app.config
-    zuul_url = config['zuul']['url']
-    zuul_endpoint = config['zuul']['status_endpoint']
-
+    config = current_app.config['zuul']
+    zuul_url = config['url']
+    zuul_endpoint = config['status_endpoint']
     url = status_endpoint(zuul_url, zuul_endpoint)
-    return fetch_json_data(endpoint=url).get('pipelines')
 
-
-def pipe_intersect(pipelines_config, pipelines_json):
-    if not pipelines_config or not pipelines_json:
-        return []
-
-    pipelines_to_show = [pipeline['name'] for pipeline in pipelines_json
-                         if pipeline['name'] in pipelines_config]
-    return pipelines_to_show
+    result = []
+    try:
+        result = fetch_json_data(endpoint=url).get('pipelines')
+    except RemoteServerError:
+        print("Couldn't fetch .json file")
+    return result
 
 
 def make_queues(pipelines, pipename, zuul_url):

--- a/acid/utils.py
+++ b/acid/utils.py
@@ -5,6 +5,5 @@ def pipe_intersect(pipelines_config, pipelines_json):
     if not pipelines_config or not pipelines_json:
         return []
 
-    pipelines_to_show = [pipeline['name'] for pipeline in pipelines_json
-                         if pipeline['name'] in pipelines_config]
-    return pipelines_to_show
+    return [pipeline['name'] for pipeline in pipelines_json
+            if pipeline['name'] in pipelines_config]

--- a/acid/utils.py
+++ b/acid/utils.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+
+def pipe_intersect(pipelines_config, pipelines_json):
+    if not pipelines_config or not pipelines_json:
+        return []
+
+    pipelines_to_show = [pipeline['name'] for pipeline in pipelines_json
+                         if pipeline['name'] in pipelines_config]
+    return pipelines_to_show


### PR DESCRIPTION
Now dashboard and dropdown menu for pipelines status show only pipelines that are intersections of pipelines lists from `status.json` and `config/settings.yml`. If none of the pipelines is present in both sets nothing is displayed.