### PR TITLE
Test modularity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,18 @@ lint: ## check code style and formatting with flake8
 	flake8
 
 test-unit: missing-conf ## run all unit tests
-	SETTINGS_PATH=$(SETTINGS_TEST) FLASK_APP=$(APP) pytest -m unit
+ifndef FEATURE
+	-SETTINGS_PATH=$(SETTINGS_TEST) FLASK_APP=$(APP) pytest -m unit
+else
+	-SETTINGS_PATH=$(SETTINGS_TEST) FLASK_APP=$(APP) pytest -m 'unit and $(FEATURE)'
+endif
 
 test-integration: missing-conf ## run all integration tests
-	SETTINGS_PATH=$(SETTINGS_TEST) FLASK_APP=$(APP) pytest -m integration
+ifndef FEATURE
+	-SETTINGS_PATH=$(SETTINGS_TEST) FLASK_APP=$(APP) pytest -m integration
+else
+	-SETTINGS_PATH=$(SETTINGS_TEST) FLASK_APP=$(APP) pytest -m 'integration and $(FEATURE)'
+endif
 
 test: test-unit test-integration ## run all tests
 

--- a/acid/features/auth/tests/test_controller.py
+++ b/acid/features/auth/tests/test_controller.py
@@ -7,6 +7,7 @@ from .. import service
 
 
 @pytest.mark.integration
+@pytest.mark.auth
 class TestSignInAndOut:
     def run_scenario(self):
         client = app.test_client()
@@ -32,6 +33,7 @@ class TestSignInAndOut:
 
 
 @pytest.mark.integration
+@pytest.mark.auth
 def test_redirect_to_launchpad_to_sign_in():
     with app.test_request_context():
         client = app.test_client()

--- a/acid/features/auth/tests/test_model.py
+++ b/acid/features/auth/tests/test_model.py
@@ -9,6 +9,7 @@ from ..model import User, get_current_user
 
 
 @pytest.mark.unit
+@pytest.mark.auth
 class TestUserModel(TestWithAppContext):
     def test_create_user_obj(self):
         User(full_name="Test User", email="test.user@acid.test")

--- a/acid/features/history/tests/test_controller.py
+++ b/acid/features/history/tests/test_controller.py
@@ -13,6 +13,7 @@ from acid.tests import DatabaseTestCase
 
 @db_session
 @pytest.mark.integration
+@pytest.mark.history
 class TestBuildHistory(DatabaseTestCase):
     client = app.test_client()
 

--- a/acid/features/history/tests/test_model.py
+++ b/acid/features/history/tests/test_model.py
@@ -13,6 +13,7 @@ from ..model import ZuulBuildSet
 
 
 @pytest.mark.unit
+@pytest.mark.history
 class TestZuulBuildSet(DatabaseTestCase):
     @db_session
     def test_start_datetime_should_return_lowest_time(self, make_buildset):
@@ -148,6 +149,7 @@ class TestZuulBuildSet(DatabaseTestCase):
 
 
 @pytest.mark.unit
+@pytest.mark.history
 class TestBuildSetPaginated:
     def test_create_buildsets_history_object(self, mocker):
         mocker.patch.object(ZuulBuildSet, 'get_for_pipeline')

--- a/acid/features/history/tests/test_pagination.py
+++ b/acid/features/history/tests/test_pagination.py
@@ -5,6 +5,7 @@ from ..service import Paginator, pagination
 
 
 @pytest.mark.unit
+@pytest.mark.history
 class TestPagination:
     def test_zero_buildsets_should_return_empty_paginator(self):
         paginator = pagination(number_of_buildsets=0,

--- a/acid/features/status/tests/test_service.py
+++ b/acid/features/status/tests/test_service.py
@@ -10,6 +10,7 @@ from ..model import PipelineStat
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestServicePipelineStats:
     def test_pipelines_stats_returns_empty_when_no_pipelines(self,
                                                              load_status_data):
@@ -48,6 +49,7 @@ class TestServicePipelineStats:
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestServiceEndpointStatus:
     def test_status_endpoint_returns_expected_when_no_slashes(self):
         result = service.status_endpoint(zuul_url='http://fake.url',
@@ -69,6 +71,7 @@ class TestServiceEndpointStatus:
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestServiceFetchData(TestWithAppContext):
     def test_fetch_raise_when_cant_download(self, mocker):
         requests = mocker.patch.object(service, 'requests')
@@ -89,6 +92,7 @@ class TestServiceFetchData(TestWithAppContext):
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestServiceMakeQueues(TestWithAppContext):
     def test_raises_when_no_queues(self, load_status_data):
         resources = load_status_data(name='status_no_queues')

--- a/acid/features/status/tests/test_status.py
+++ b/acid/features/status/tests/test_status.py
@@ -7,6 +7,7 @@ from ..time_utils import (epoch_to_datetime, milliseconds_to_seconds,
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestTimeTracker:
     def test_none_start_to_datetime_should_return_none(self, time_tracker):
         time_tracker.start = None
@@ -41,6 +42,7 @@ class TestTimeTracker:
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestJob:
     def test_create_should_return_expected_data(self):
         job_data = {"url": "http://fake_url",
@@ -111,6 +113,7 @@ class TestJob:
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestBuildset:
     def _assert_buildset_equal(self, buildset1, buildset2):
         # assumes buildset has empty job list
@@ -299,6 +302,7 @@ class TestBuildset:
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestQueue:
     def test_queue_should_return_valid_queue(self, queue):
         test_queue = queue

--- a/acid/features/status/tests/test_time.py
+++ b/acid/features/status/tests/test_time.py
@@ -6,6 +6,7 @@ from ..time_utils import (epoch_to_datetime, milliseconds_to_seconds,
 
 
 @pytest.mark.unit
+@pytest.mark.status
 class TestTimeUtils:
     def test_empty_epoch_to_datetime_should_raise_exception(self):
         with pytest.raises(TypeError):

--- a/acid/features/zuul_manager/tests/test_controller.py
+++ b/acid/features/zuul_manager/tests/test_controller.py
@@ -14,6 +14,7 @@ from ...auth import service as auth_service
 
 
 @pytest.mark.integration
+@pytest.mark.zuul_manager
 class TestControlPanel(IntegrationTestCase):
     def test_guest_user_cant_see_zuul_management(self, get_user, mocker):
         user = get_user('admin')

--- a/acid/features/zuul_manager/tests/test_manager.py
+++ b/acid/features/zuul_manager/tests/test_manager.py
@@ -6,7 +6,8 @@ from ..exceptions import ZuulManagerConfig
 
 
 @pytest.mark.unit
-class TestZuulConnector():
+@pytest.mark.zuul_manager
+class TestZuulConnector:
     def test_raise_when_no_user_key_file(self, path_to_test_file):
         with pytest.raises(ZuulManagerConfig):
             ZuulManager(host="host",


### PR DESCRIPTION
Test can now be run for separate features:
`make test FEATURE=name_of_the_feature`
Feature separation works for test-unit and test-integration as well.

If `FEATURE` isn't passed to `make` tests for all features are run.
To assign test to the feature decorate test class with: `@pytest.mark.name_of_the_feature` 

All errors from `pytest` are displayed but ignored, so if test case for `name_of_the_feature` is only present in one test set (`unit` or `integration`) it won't stop after finding no matches in the other set.