### PR TITLE
Pipeline and branch filtering for zuul manager

### DIFF
--- a/acid/features/zuul_manager/controller.py
+++ b/acid/features/zuul_manager/controller.py
@@ -14,8 +14,28 @@ zuul_manager = Blueprint('zuul_manager', __name__,
 @zuul_manager.route('/zuul_manager')
 @admin_required
 def show_panel():
-    pipelines = current_app.config['zuul']['build_enqueue']['pipelines']
-    return render_template('zuul_manager.html', pipelines=pipelines)
+    config_pipelines = current_app.config['zuul']['build_enqueue']['pipelines']
+
+    pipelines_arg = request.args.getlist('pipeline')
+    branches_arg = request.args.getlist('branch')
+
+    pipelines = config_pipelines
+
+    # add pipeline filtering
+    if pipelines_arg:
+        pipelines = {pipeline: branches for pipeline, branches
+                     in pipelines.items() if pipeline in pipelines_arg}
+
+    # add branch filtering
+    if branches_arg:
+        pipelines = {k: [v2 for v2 in v if v2 in branches_arg]
+                     for k, v in pipelines.items()}
+
+    branches_list = set([i for v in config_pipelines.values() for i in v])
+
+    return render_template('zuul_manager.html', pipelines=pipelines,
+                           pipelines_list=config_pipelines,
+                           branches_list=branches_list)
 
 
 @zuul_manager.route('/zuul_manager/manage', methods=['POST'])
@@ -27,19 +47,18 @@ def manage():
 
     zuul_manager = ZuulManager(**current_app.config['zuul']['manager'])
 
-    for pipeline in current_app.config['zuul']['build_enqueue']['pipelines']:
-        if pipeline_name not in pipeline.keys():
-            continue
-        if branch not in pipeline[pipeline_name]:
-            continue
+    pipelines = current_app.config['zuul']['build_enqueue']['pipelines']
+    if pipeline_name not in pipelines.keys():
+        abort(requests.codes.bad_request)
+    if branch not in pipelines[pipeline_name]:
+        abort(requests.codes.bad_request)
 
-        if action == 'start':
-            zuul_manager.enqueue(pipeline_name, branch)
-        elif action == 'stop':
-            zuul_manager.dequeue(pipeline_name, branch)
-        else:
-            abort(requests.codes.bad_request)
+    if action == 'start':
+        zuul_manager.enqueue(pipeline_name, branch)
+    elif action == 'stop':
+        zuul_manager.dequeue(pipeline_name, branch)
+    else:
+        abort(requests.codes.bad_request)
 
-        flash('Job started. It might take a while for zuul to update', 'info')
-        return redirect(url_for('status.show_status', pipename=pipeline_name))
-    abort(requests.codes.bad_request)
+    flash('Job started. It might take a while for zuul to update', 'info')
+    return redirect(url_for('status.show_status', pipename=pipeline_name))

--- a/acid/features/zuul_manager/controller.py
+++ b/acid/features/zuul_manager/controller.py
@@ -21,19 +21,21 @@ def show_panel():
 
     pipelines = config_pipelines
 
-    # add pipeline filtering
     if pipelines_arg:
-        pipelines = {pipeline: branches for pipeline, branches
-                     in pipelines.items() if pipeline in pipelines_arg}
+        pipelines = {pipe: branches for pipe, branches
+                     in pipelines.items() if pipe in pipelines_arg}
 
-    # add branch filtering
     if branches_arg:
-        pipelines = {k: [v2 for v2 in v if v2 in branches_arg]
-                     for k, v in pipelines.items()}
+        pipelines = {pipe: [branch for branch in branches
+                            if branch in branches_arg]
+                     for pipe, branches in pipelines.items()}
 
-    branches_list = set([i for v in config_pipelines.values() for i in v])
+    branches_list = set([branch for branches in config_pipelines.values()
+                         for branch in branches])
 
     return render_template('zuul_manager.html', pipelines=pipelines,
+                           pipelines_arg=pipelines_arg,
+                           branches_arg=branches_arg,
                            pipelines_list=config_pipelines,
                            branches_list=branches_list)
 

--- a/acid/features/zuul_manager/controller.py
+++ b/acid/features/zuul_manager/controller.py
@@ -30,8 +30,8 @@ def show_panel():
                             if branch in branches_arg]
                      for pipe, branches in pipelines.items()}
 
-    branches_list = set([branch for branches in config_pipelines.values()
-                         for branch in branches])
+    branches_list = {branch for branches in config_pipelines.values()
+                     for branch in branches}
 
     return render_template('zuul_manager.html', pipelines=pipelines,
                            pipelines_arg=pipelines_arg,

--- a/acid/features/zuul_manager/tests/test_controller.py
+++ b/acid/features/zuul_manager/tests/test_controller.py
@@ -41,10 +41,10 @@ class TestControlPanel(IntegrationTestCase):
         # in config. Regex looks inside of body tag in order to ensure it's
         # displayed in specific site content and not in other elements.
         pattern = '<body>.*'
-        for pipes in current_app.config['zuul']['build_enqueue']['pipelines']:
-            for pipeline, branches in pipes.items():
-                for branch in branches:
-                    pattern += '.*'.join([pipeline, branch, 'START', 'STOP.*'])
+        pipes = current_app.config['zuul']['build_enqueue']['pipelines']
+        for pipeline, branches in pipes.items():
+            for branch in branches:
+                pattern += '.*'.join([pipeline, branch, 'START', 'STOP.*'])
         pattern += '</body>'
         pattern = str.encode(pattern)
         assert re.search(pattern, rendered_template) is not None

--- a/acid/templates/zuul_manager.html
+++ b/acid/templates/zuul_manager.html
@@ -7,6 +7,28 @@
                 <h1>Zuul manager</h1>
             </div>
         </div>
+
+        <div class="container mb-5">
+            <div class="row justify-content-center">
+                    <form class="form-inline col-8" action="">
+                        <div class="form-group sm-2" style="width: 100%">
+                            <select class="custom-select-pipeline form-control mb-2 mr-sm-2" multiple="multiple" name="pipeline" style="width: 40%">
+                                {%  for pipename in pipelines_list %}
+                                    <option>{{ pipename }}</option>
+                                {%  endfor %}
+                            </select>
+                            <select class="custom-select-branch form-control mb-2 mr-sm-2" multiple="multiple" name="branch" style="width: 40%">
+                                {%  for branch in branches_list %}
+                                    <option>{{ branch }}</option>
+                                {%  endfor %}
+                            </select>
+                            <button type="submit" class="btn btn-primary">Filter</button>
+                        </div>
+                    </form>
+            </div>
+        </div>
+
+
         <div class="row mt-5 mb-2">
             <div class="col-md-12 col-lg-6 offset-lg-3">
                 <div class="table-responsive">
@@ -19,22 +41,20 @@
                             </tr>
                         </thead>
                         <tbody>
-                        {% for pipelines in pipelines %}
-                            {% for pipeline_name, branches in pipelines.items() %}
-                                {% for branch in branches %}
-                                    <tr>
-                                        <td> {{ pipeline_name }}</td>
-                                        <td> {{ branch }}</td>
-                                        <td>
-                                            <form class="form" method="POST" action="{{ url_for('zuul_manager.manage') }}">
-                                                <input type="hidden" name="branch" value="{{ branch }}">
-                                                <input type="hidden" name="pipeline_name" value="{{ pipeline_name }}">
-                                                <button type="submit" class="btn btn-success" name="action" value="start">START</button>
-                                                <button type="submit" class="btn btn-danger" name="action" value="stop">STOP</button>
-                                            </form>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
+                        {% for pipeline_name, branches in pipelines.items() %}
+                            {% for branch in branches %}
+                                <tr>
+                                    <td> {{ pipeline_name }}</td>
+                                    <td> {{ branch }}</td>
+                                    <td>
+                                        <form class="form" method="POST" action="{{ url_for('zuul_manager.manage') }}">
+                                            <input type="hidden" name="branch" value="{{ branch }}">
+                                            <input type="hidden" name="pipeline_name" value="{{ pipeline_name }}">
+                                            <button type="submit" class="btn btn-success" name="action" value="start">START</button>
+                                            <button type="submit" class="btn btn-danger" name="action" value="stop">STOP</button>
+                                        </form>
+                                    </td>
+                                </tr>
                             {% endfor %}
                         {% endfor %}
                         </tbody>

--- a/acid/templates/zuul_manager.html
+++ b/acid/templates/zuul_manager.html
@@ -14,12 +14,12 @@
                         <div class="form-group sm-2" style="width: 100%">
                             <select class="custom-select-pipeline form-control mb-2 mr-sm-2" multiple="multiple" name="pipeline" style="width: 40%">
                                 {%  for pipename in pipelines_list %}
-                                    <option>{{ pipename }}</option>
+                                    <option {% if pipename in pipelines_arg %} selected="selected" {% endif %}>{{ pipename }}</option>
                                 {%  endfor %}
                             </select>
                             <select class="custom-select-branch form-control mb-2 mr-sm-2" multiple="multiple" name="branch" style="width: 40%">
                                 {%  for branch in branches_list %}
-                                    <option>{{ branch }}</option>
+                                    <option {% if branch in branches_arg %} selected="selected" {% endif %}>{{ branch }}</option>
                                 {%  endfor %}
                             </select>
                             <button type="submit" class="btn btn-primary">Filter</button>

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -54,13 +54,13 @@ zuul:
   build_enqueue:
     # Specify pipelines and branches which can be managed from UI.
     # Format:
-    # - <pipeline name>:
+    # <pipeline name>:
     #   - <branch>
     #   - <branch> 
     pipelines:
-      - periodic-nightly:
-          - master
-          - R5.0
+      periodic-nightly:
+        - master
+        - R5.0
 
   # Data used by PonyORM to bind database object with specyfic database
   # Read more: https://docs.ponyorm.com/database.html#binding-the-database-object-to-a-specific-database 

--- a/config/test/settings_test.yml.sample
+++ b/config/test/settings_test.yml.sample
@@ -27,9 +27,9 @@ zuul:
     - experimental-provision
   build_enqueue:
     pipelines:
-      - periodic-nightly:
-          - master
-          - R5.0
+      periodic-nightly:
+        - master
+        - R5.0
   database:
     provider: 'mysql'
     host: '10.10.10.5'

--- a/static/script.js
+++ b/static/script.js
@@ -57,7 +57,7 @@ $(function () {
     })
   })
 
-    $(document).ready(function () {
+  $(document).ready(function () {
     $('.custom-select-branch').select2({
       placeholder: 'Select branch'
     })

--- a/static/script.js
+++ b/static/script.js
@@ -50,6 +50,18 @@ $(function () {
       placeholder: 'Select branch'
     })
   })
+
+  $(document).ready(function () {
+    $('.custom-select-pipeline').select2({
+      placeholder: 'Select pipeline'
+    })
+  })
+
+    $(document).ready(function () {
+    $('.custom-select-branch').select2({
+      placeholder: 'Select branch'
+    })
+  })
 })
 
 function enableAutoRefresh () { // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Added similar functionality to zuul manager as in build history. Now users can filter manual starting/stopping jobs by pipelines and/or branches.